### PR TITLE
Use the stored phase space in NCEL and CCQE axial/vec RW calculators

### DIFF
--- a/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
@@ -129,7 +129,7 @@ double GReWeightNuXSecCCQEaxial::CalcWeight(const genie::EventRecord & event)
   // (normalized to constant integrated cross section)
   //
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);

--- a/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
@@ -126,7 +126,7 @@ double GReWeightNuXSecCCQEvec::CalcWeight(const genie::EventRecord & event)
   // (normalized to constant integrated cross section)
   //
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);

--- a/src/RwCalculators/GReWeightNuXSecNCEL.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCEL.cxx
@@ -155,7 +155,7 @@ double GReWeightNuXSecNCEL::CalcWeight(const genie::EventRecord & event)
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {

--- a/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
+++ b/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
@@ -123,8 +123,6 @@ bool GReWeightXSecEmpiricalMEC::IsHandled(GSyst_t syst) const {
 }
 void GReWeightXSecEmpiricalMEC::SetSystematic(GSyst_t syst, double twk_dial) {
   if (!this->IsHandled(syst)) {
-    LOG("ReW", pWARN) << "Systematic " << GSyst::AsString(syst)
-                      << " is not handled by GReWeightXSecEmpiricalMEC";
     return;
   }
 


### PR DESCRIPTION
Change to using the phase space with which the event was generated, rather than `kPSQ2fE`, when calculating cross sections for NCEL, CCQEaxial, and CCQEvec reweighting.

Also silence a harmless warning from the empirical MEC calculator.