### PR TITLE
remove exit() from warning about 'unitarity' in Intranuke knobs

### DIFF
--- a/src/RwCalculators/GReWeightINukeParams.cxx
+++ b/src/RwCalculators/GReWeightINukeParams.cxx
@@ -427,7 +427,6 @@ double GReWeightINukeParams::Fates::ActualTwkDial(GSyst_t syst, double KE) const
   if(TMath::Abs(sum_fate_fraction_all-1) > 0.01) {
       LOG("ReW", pWARN) << "Unitarity violation level exceeded 1 part in 100.";
       LOG("ReW", pWARN) << "Current sum of all fate fractions = " << sum_fate_fraction_all;
-      exit(1);
   }
 
   map<GSyst_t, double>::const_iterator dial_iter = fSystValuesActual.find(syst);

--- a/src/RwCalculators/GReWeightNonResonanceBkg.cxx
+++ b/src/RwCalculators/GReWeightNonResonanceBkg.cxx
@@ -198,7 +198,7 @@ void GReWeightNonResonanceBkg::Init(void)
 
   // Get the "common" (shared) parameters
   AlgConfigPool * conf_pool = AlgConfigPool::Instance();
-  Registry * user_config = conf_pool->CommonParameterList("NonResBackground");
+  Registry * user_config = conf_pool->CommonList("Param", "NonResBackground");
   if ( ! user_config ) {
     std::cerr << "no CommonParameterList(\"NonResBackground\")" << std::endl;
     exit(-1);

--- a/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
@@ -129,7 +129,7 @@ double GReWeightNuXSecCCQEaxial::CalcWeight(const genie::EventRecord & event)
   // (normalized to constant integrated cross section)
   //
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);

--- a/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
@@ -126,7 +126,7 @@ double GReWeightNuXSecCCQEvec::CalcWeight(const genie::EventRecord & event)
   // (normalized to constant integrated cross section)
   //
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);

--- a/src/RwCalculators/GReWeightNuXSecNCEL.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCEL.cxx
@@ -155,7 +155,7 @@ double GReWeightNuXSecNCEL::CalcWeight(const genie::EventRecord & event)
   interaction->KinePtr()->UseSelectedKinematics();
   interaction->SetBit(kIAssumeFreeNucleon);
 
-  const KinePhaseSpace_t phase_space = kPSQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {

--- a/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
+++ b/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
@@ -123,8 +123,6 @@ bool GReWeightXSecEmpiricalMEC::IsHandled(GSyst_t syst) const {
 }
 void GReWeightXSecEmpiricalMEC::SetSystematic(GSyst_t syst, double twk_dial) {
   if (!this->IsHandled(syst)) {
-    LOG("ReW", pWARN) << "Systematic " << GSyst::AsString(syst)
-                      << " is not handled by GReWeightXSecEmpiricalMEC";
     return;
   }
 

--- a/src/RwFramework/GSyst.h
+++ b/src/RwFramework/GSyst.h
@@ -250,6 +250,7 @@ public:
      case ( kXSecTwkDial_NormDISCC        ) : return "NormDISCC";            break;
      case ( kXSecTwkDial_RnubarnuCC       ) : return "RnubarnuCC";           break;
      case ( kXSecTwkDial_DISNuclMod       ) : return "DISNuclMod";           break;
+     case ( kXSecTwkDial_NC               ) : return "NC";                   break;
      case ( kHadrAGKYTwkDial_xF1pi        ) : return "AGKYxF1pi";            break;
      case ( kHadrAGKYTwkDial_pT1pi        ) : return "AGKYpT1pi";            break;
      case ( kHadrNuclTwkDial_FormZone     ) : return "FormZone";             break;


### PR DESCRIPTION
An exit() was introduced into the code that follows a warning
about "unitarity" in the Intranuke rescattering knobs during
refactoring (commit d74a45ca94e69c05cb1d48f234c59bfbbd0f7ae3).

This is not a rare condition and inhibits users successfully using
the reweight code over large sets of events.

Propose to return to only printing the warning and not exit()ing.