### PR TITLE
Only assume a free nucleon for phase space kPSQ2fE

### DIFF
--- a/src/RwCalculators/GReWeightNuXSecCCQE.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQE.cxx
@@ -443,11 +443,14 @@ double GReWeightNuXSecCCQE::CalcWeightMa(const genie::EventRecord & event)
   Interaction * interaction = event.Summary();
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
 
   // Retrieve the kinematic phase space used to generate the event
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
   double old_xsec = event.DiffXSec();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
     double calc_old_xsec = fXSecModelDef->XSec(interaction, phase_space);
@@ -473,7 +476,10 @@ double GReWeightNuXSecCCQE::CalcWeightMa(const genie::EventRecord & event)
 //LOG("ReW", pDEBUG) << "new weight = " << new_weight;
 
   interaction->KinePtr()->ClearRunningValues();
-  interaction->ResetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
   return new_weight;
 }
@@ -486,11 +492,14 @@ double GReWeightNuXSecCCQE::CalcWeightMaShape(const genie::EventRecord & event)
   Interaction * interaction = event.Summary();
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
 
   // Retrieve the kinematic phase space used to generate the event
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
   double old_xsec = event.DiffXSec();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
     double calc_old_xsec = fXSecModelDef->XSec(interaction, phase_space);
@@ -524,7 +533,10 @@ double GReWeightNuXSecCCQE::CalcWeightMaShape(const genie::EventRecord & event)
 //LOG("ReW", pDEBUG) << "new weight (normalized to const integral) = " << new_weight;
 
   interaction->KinePtr()->ClearRunningValues();
-  interaction->ResetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
 #ifdef _G_REWEIGHT_CCQE_DEBUG_
   double E  = interaction->InitState().ProbeE(kRfHitNucRest);
@@ -548,11 +560,14 @@ double GReWeightNuXSecCCQE::CalcWeightZExp(const genie::EventRecord & event)
   Interaction * interaction = event.Summary();
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
 
   // Retrieve the kinematic phase space used to generate the event
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
   double old_xsec = event.DiffXSec();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
     double calc_old_xsec = fXSecModelDef->XSec(interaction, phase_space);
@@ -571,7 +586,10 @@ double GReWeightNuXSecCCQE::CalcWeightZExp(const genie::EventRecord & event)
   double new_weight = old_weight * (new_xsec/old_xsec);
 
   interaction->KinePtr()->ClearRunningValues();
-  interaction->ResetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
   return new_weight;
 }

--- a/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
@@ -132,7 +132,10 @@ double GReWeightNuXSecCCQEaxial::CalcWeight(const genie::EventRecord & event)
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
@@ -175,6 +178,11 @@ double GReWeightNuXSecCCQEaxial::CalcWeight(const genie::EventRecord & event)
     E,Q2,weight,def_integrated_xsec,zexp_integrated_xsec,old_xsec,zexp_xsec);
 #endif
 
+  interaction->KinePtr()->ClearRunningValues();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
   return weight;
 }

--- a/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
@@ -129,7 +129,10 @@ double GReWeightNuXSecCCQEvec::CalcWeight(const genie::EventRecord & event)
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
@@ -170,6 +173,11 @@ double GReWeightNuXSecCCQEvec::CalcWeight(const genie::EventRecord & event)
     E,Q2,weight,def_integrated_xsec,dpl_integrated_xsec,def_xsec,dpl_xsec);
 #endif
 
+  interaction->KinePtr()->ClearRunningValues();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
   return weight;
 }

--- a/src/RwCalculators/GReWeightNuXSecHelper.cxx
+++ b/src/RwCalculators/GReWeightNuXSecHelper.cxx
@@ -121,7 +121,7 @@ double GReWeightNuXSecHelper::NewWeight(
 
   // hack to match what was stored during event generation
   // -- is currently revisited --
-  if(interaction.ProcInfo().IsQuasiElastic())
+  if(interaction.ProcInfo().IsQuasiElastic() && kps == kPSQ2fE)
 		interaction.SetBit(kIAssumeFreeNucleon);
 
   double old_xsec   = event.DiffXSec();
@@ -137,7 +137,7 @@ double GReWeightNuXSecHelper::NewWeight(
   }
 
   // hack - closing parenthesis
-  if(interaction.ProcInfo().IsQuasiElastic())
+  if(interaction.ProcInfo().IsQuasiElastic() && kps == kPSQ2fE)
   		interaction.ResetBit(kIAssumeFreeNucleon);
 
   // Clear the 'running' kinematics buffer

--- a/src/RwCalculators/GReWeightNuXSecNCEL.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCEL.cxx
@@ -153,9 +153,12 @@ double GReWeightNuXSecNCEL::CalcWeight(const genie::EventRecord & event)
   if(!tweaked) return 1.0;
 
   interaction->KinePtr()->UseSelectedKinematics();
-  interaction->SetBit(kIAssumeFreeNucleon);
 
   const KinePhaseSpace_t phase_space = event.DiffXSecVars();
+
+  if (phase_space == kPSQ2fE) {
+    interaction->SetBit(kIAssumeFreeNucleon);
+  }
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
@@ -187,7 +190,10 @@ double GReWeightNuXSecNCEL::CalcWeight(const genie::EventRecord & event)
 #endif
 
   interaction->KinePtr()->ClearRunningValues();
-  interaction->ResetBit(kIAssumeFreeNucleon);
+
+  if (phase_space == kPSQ2fE) {
+    interaction->ResetBit(kIAssumeFreeNucleon);
+  }
 
   return new_weight;
 }


### PR DESCRIPTION
Change the reweight calculators to only AssumeFreeNucleon in case the
phase space is `kPSQ2fE`, since the assumption is no longer generally
valid in Generator v3.00.04, and this leads to cross section mismatches.

Ideally we would use a model identifier to set this flag, but since
it's not readily available we use the phase space stored in the
event record as a proxy.