### PR TITLE
Fix fate fraction problem in Reweight

### DIFF
--- a/src/RwCalculators/GReWeightINukeParams.cxx
+++ b/src/RwCalculators/GReWeightINukeParams.cxx
@@ -329,7 +329,7 @@ double GReWeightINukeParams::Fates::ActualTwkDial(GSyst_t syst, double KE) const
        double curr_frac  = genie::utils::rew::FateFraction(curr_syst, KE, fTargetA, frac_scale);
 
        double curr_frac_new     = (curr_is_cushion) ? 0 : curr_frac * (1./sum_nocushion_fate_fraction_twk);
-       double frac_scale_new    = genie::utils::rew::WhichFateFractionScaleFactor(curr_syst, KE, curr_frac_new);
+       double frac_scale_new    = genie::utils::rew::WhichFateFractionScaleFactor(curr_syst, KE, fTargetA, curr_frac_new);
        double curr_twk_dial_new = (frac_scale_new - 1.) / fractional_frac_err;
 
        fSystValuesActual[curr_syst] = curr_twk_dial_new;

--- a/src/RwCalculators/GReWeightUtils.cxx
+++ b/src/RwCalculators/GReWeightUtils.cxx
@@ -231,15 +231,22 @@ double genie::utils::rew::FateFraction(genie::rew::GSyst_t syst, double kinE,
 }
 //____________________________________________________________________________
 double genie::utils::rew::WhichFateFractionScaleFactor(
-    genie::rew::GSyst_t syst, double kinE, double fate_frac)
+    genie::rew::GSyst_t syst, double kinE, int target_A, double fate_frac)
 {
-  double fate_frac_nominal = FateFraction(syst,kinE,1.);
+  double fate_frac_nominal = FateFraction(syst, kinE, target_A, 1.0);
 
-  if(TMath::Abs(fate_frac-fate_frac_nominal) < kASmallNum) return 0;
+  // Avoid NaNs if both the nominal value and the tweaked value are zero
+  if ( fate_frac_nominal == 0. && fate_frac == 0. ) return 1.;
 
-  if(fate_frac_nominal <= 0) { return -99999; }
+  if ( fate_frac_nominal <= 0. ) {
+    // We're having some sort of problem with the fate fraction calculation
+    LOG("ReW", pERROR) << "Nonpositive nominal fate fraction"
+      << " encountered in genie::utils::rew::WhichFateFractionScaleFactor()";
+    return -99999.;
+  }
 
-  double scale = TMath::Max(0.,fate_frac)/fate_frac_nominal;
+  double scale = std::max(0., fate_frac) / fate_frac_nominal;
+
   return scale;
 }
 //____________________________________________________________________________

--- a/src/RwCalculators/GReWeightUtils.h
+++ b/src/RwCalculators/GReWeightUtils.h
@@ -53,12 +53,12 @@ namespace rew   {
   // Return the fraction of the hadron rescatering fate described by the input
   // systematic enumeration at the input hadron kinetic energy for a hit nucleus
   // with the given mass number
-  double FateFraction(genie::rew::GSyst_t syst, double kinE, int target_A, double frac_scale_factor=1.);
+  double FateFraction(genie::rew::GSyst_t syst, double kinE, int target_A, double frac_scale_factor);
 
   // Return the required fate fraction scaling factor for the fate described by the input
   // systematic enumeration, at the input hadron kinetic energy, so that the fate fraction
   // becomes the input one.
-  double WhichFateFractionScaleFactor(genie::rew::GSyst_t syst, double kinE, double fate_frac);
+  double WhichFateFractionScaleFactor(genie::rew::GSyst_t syst, double kinE, int target_A, double fate_frac);
 
   // Check whether the input event is hadronized by AGKY
   bool  HadronizedByAGKY(const EventRecord & event);


### PR DESCRIPTION
This pull request should probably supersede #4, although we may want to revisit removing the hard exit when Reweight encounters significant unitarity violation.

Fix erroneous call to genie::utils::rew::FateFraction() in genie::utils::rew::WhichFateFractionScaleFactor(). The former was updated
for Reweight v1.0.0 to avoid relying on a hard-coded nuclear mass number
(see commit 7b544ab6a1). Usage of FateFraction() in
WhichFateFractionScaleFactor() had not yet been adjusted to take this
change into account. The failure to do so led to incorrect lookups of the
untweaked fate fraction. A scaling factor of 1.0 (corresponding to the
untweaked value) was mistakenly interpreted as a mass number (and
implicitly converted to int), leading to lookups for A = 1 instead of the
correct target nucleus. The impact of this bug on users was occasional
severe unitarity violation when reweighting hadron fate fractions.