### PR TITLE
Refactor GSystUncertainty to allow configuration of 1-sigma uncertainties via XML

### DIFF
--- a/src/RwFramework/GSyst.cxx
+++ b/src/RwFramework/GSyst.cxx
@@ -1,0 +1,114 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2019, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+
+ Authors: Costas Andreopoulos <costas.andreopoulos \at stfc.ac.uk>
+          University of Liverpool & STFC Rutherford Appleton Lab
+
+          Steven Gardiner <gardiner \at fnal.gov>
+          Fermi National Accelerator Laboratory
+*/
+//____________________________________________________________________________
+
+// GENIE/Reweight includes
+#include "RwFramework/GSyst.h"
+
+using namespace genie;
+using namespace genie::rew;
+
+std::map<GSyst_t, std::string> GSyst::fGSystToStringMap
+  = GSyst::BuildGSystToStringMap();
+
+// There are better ways of doing this in C++11. I'd recommend
+// revisiting this for GENIE 4. - S. Gardiner
+std::map<GSyst_t, std::string> GSyst::BuildGSystToStringMap() {
+  std::map<GSyst_t, std::string> temp_map;
+
+  temp_map[ kXSecTwkDial_MaNCEL ]           = "MaNCEL";
+  temp_map[ kXSecTwkDial_EtaNCEL ]          = "EtaNCEL";
+  temp_map[ kXSecTwkDial_NormCCQE ]         = "NormCCQE";
+  temp_map[ kXSecTwkDial_NormCCQEenu ]      = "NormCCQEenu";
+  temp_map[ kXSecTwkDial_MaCCQE ]           = "MaCCQE";
+  temp_map[ kXSecTwkDial_MaCCQEshape ]      = "MaCCQEshape";
+  temp_map[ kXSecTwkDial_E0CCQE ]           = "E0CCQE";
+  temp_map[ kXSecTwkDial_E0CCQEshape ]      = "E0CCQEshape";
+  temp_map[ kXSecTwkDial_ZNormCCQE ]        = "ZNormCCQE";
+  temp_map[ kXSecTwkDial_ZExpA1CCQE ]       = "ZExpA1CCQE";
+  temp_map[ kXSecTwkDial_ZExpA2CCQE ]       = "ZExpA2CCQE";
+  temp_map[ kXSecTwkDial_ZExpA3CCQE ]       = "ZExpA3CCQE";
+  temp_map[ kXSecTwkDial_ZExpA4CCQE ]       = "ZExpA4CCQE";
+  temp_map[ kXSecTwkDial_AxFFCCQEshape ]    = "AxFFCCQEshape";
+  temp_map[ kXSecTwkDial_VecFFCCQEshape ]   = "VecFFCCQEshape";
+  temp_map[ kXSecTwkDial_NormCCRES ]        = "NormCCRES";
+  temp_map[ kXSecTwkDial_MaCCRESshape ]     = "MaCCRESshape";
+  temp_map[ kXSecTwkDial_MvCCRESshape ]     = "MvCCRESshape";
+  temp_map[ kXSecTwkDial_MaCCRES ]          = "MaCCRES";
+  temp_map[ kXSecTwkDial_MvCCRES ]          = "MvCCRES";
+  temp_map[ kXSecTwkDial_NormNCRES ]        = "NormNCRES";
+  temp_map[ kXSecTwkDial_MaNCRESshape ]     = "MaNCRESshape";
+  temp_map[ kXSecTwkDial_MvNCRESshape ]     = "MvNCRESshape";
+  temp_map[ kXSecTwkDial_MaNCRES ]          = "MaNCRES";
+  temp_map[ kXSecTwkDial_MvNCRES ]          = "MvNCRES";
+  temp_map[ kXSecTwkDial_MaCOHpi ]          = "MaCOHpi";
+  temp_map[ kXSecTwkDial_R0COHpi ]          = "R0COHpi";
+  temp_map[ kXSecTwkDial_RvpCC1pi ]         = "NonRESBGvpCC1pi";
+  temp_map[ kXSecTwkDial_RvpCC2pi ]         = "NonRESBGvpCC2pi";
+  temp_map[ kXSecTwkDial_RvpNC1pi ]         = "NonRESBGvpNC1pi";
+  temp_map[ kXSecTwkDial_RvpNC2pi ]         = "NonRESBGvpNC2pi";
+  temp_map[ kXSecTwkDial_RvnCC1pi ]         = "NonRESBGvnCC1pi";
+  temp_map[ kXSecTwkDial_RvnCC2pi ]         = "NonRESBGvnCC2pi";
+  temp_map[ kXSecTwkDial_RvnNC1pi ]         = "NonRESBGvnNC1pi";
+  temp_map[ kXSecTwkDial_RvnNC2pi ]         = "NonRESBGvnNC2pi";
+  temp_map[ kXSecTwkDial_RvbarpCC1pi ]      = "NonRESBGvbarpCC1pi";
+  temp_map[ kXSecTwkDial_RvbarpCC2pi ]      = "NonRESBGvbarpCC2pi";
+  temp_map[ kXSecTwkDial_RvbarpNC1pi ]      = "NonRESBGvbarpNC1pi";
+  temp_map[ kXSecTwkDial_RvbarpNC2pi ]      = "NonRESBGvbarpNC2pi";
+  temp_map[ kXSecTwkDial_RvbarnCC1pi ]      = "NonRESBGvbarnCC1pi";
+  temp_map[ kXSecTwkDial_RvbarnCC2pi ]      = "NonRESBGvbarnCC2pi";
+  temp_map[ kXSecTwkDial_RvbarnNC1pi ]      = "NonRESBGvbarnNC1pi";
+  temp_map[ kXSecTwkDial_RvbarnNC2pi ]      = "NonRESBGvbarnNC2pi";
+  temp_map[ kXSecTwkDial_AhtBY ]            = "AhtBY";
+  temp_map[ kXSecTwkDial_BhtBY ]            = "BhtBY";
+  temp_map[ kXSecTwkDial_CV1uBY ]           = "CV1uBY";
+  temp_map[ kXSecTwkDial_CV2uBY ]           = "CV2uBY";
+  temp_map[ kXSecTwkDial_AhtBYshape ]       = "AhtBYshape";
+  temp_map[ kXSecTwkDial_BhtBYshape ]       = "BhtBYshape";
+  temp_map[ kXSecTwkDial_CV1uBYshape ]      = "CV1uBYshape";
+  temp_map[ kXSecTwkDial_CV2uBYshape ]      = "CV2uBYshape";
+  temp_map[ kXSecTwkDial_NormDISCC ]        = "NormDISCC";
+  temp_map[ kXSecTwkDial_RnubarnuCC ]       = "RnubarnuCC";
+  temp_map[ kXSecTwkDial_DISNuclMod ]       = "DISNuclMod";
+  temp_map[ kXSecTwkDial_NC ]               = "NC";
+  temp_map[ kHadrAGKYTwkDial_xF1pi ]        = "AGKYxF1pi";
+  temp_map[ kHadrAGKYTwkDial_pT1pi ]        = "AGKYpT1pi";
+  temp_map[ kHadrNuclTwkDial_FormZone ]     = "FormZone";
+  temp_map[ kINukeTwkDial_MFP_pi ]          = "MFP_pi";
+  temp_map[ kINukeTwkDial_MFP_N ]           = "MFP_N";
+  temp_map[ kINukeTwkDial_FrCEx_pi ]        = "FrCEx_pi";
+//temp_map[ kINukeTwkDial_FrElas_pi ]       = "FrElas_pi";
+  temp_map[ kINukeTwkDial_FrInel_pi ]       = "FrInel_pi";
+  temp_map[ kINukeTwkDial_FrAbs_pi ]        = "FrAbs_pi";
+  temp_map[ kINukeTwkDial_FrPiProd_pi ]     = "FrPiProd_pi";
+  temp_map[ kINukeTwkDial_FrCEx_N ]         = "FrCEx_N";
+//temp_map[ kINukeTwkDial_FrElas_N ]        = "FrElas_N";
+  temp_map[ kINukeTwkDial_FrInel_N ]        = "FrInel_N";
+  temp_map[ kINukeTwkDial_FrAbs_N ]         = "FrAbs_N";
+  temp_map[ kINukeTwkDial_FrPiProd_N ]      = "FrPiProd_N";
+  temp_map[ kSystNucl_CCQEPauliSupViaKF ]   = "CCQEPauliSupViaKF";
+  temp_map[ kSystNucl_CCQEMomDistroFGtoSF ] = "CCQEMomDistroFGtoSF";
+  temp_map[ kRDcyTwkDial_BR1gamma ]         = "RDecBR1gamma";
+  temp_map[ kRDcyTwkDial_BR1eta ]           = "RDecBR1eta";
+  temp_map[ kRDcyTwkDial_Theta_Delta2Npi ]  = "Theta_Delta2Npi";
+  temp_map[ kXSecTwkDial_EmpMEC_Mq2d ]      = "EmpMEC_Mq2d";
+  temp_map[ kXSecTwkDial_EmpMEC_Mass ]      = "EmpMEC_Mass";
+  temp_map[ kXSecTwkDial_EmpMEC_Width ]     = "EmpMEC_Width";
+  temp_map[ kXSecTwkDial_EmpMEC_FracPN_NC ] = "EmpMEC_FracPN_NC";
+  temp_map[ kXSecTwkDial_EmpMEC_FracPN_CC ] = "EmpMEC_FracPN_CC";
+  temp_map[ kXSecTwkDial_EmpMEC_FracCCQE ]  = "EmpMEC_FracCCQE";
+  temp_map[ kXSecTwkDial_EmpMEC_FracNCQE ]  = "EmpMEC_FracNCQE";
+  temp_map[ kXSecTwkDial_EmpMEC_FracPN_EM ] = "EmpMEC_FracPN_EM";
+  temp_map[ kXSecTwkDial_EmpMEC_FracEMQE ]  = "EmpMEC_FracEMQE";
+
+  return temp_map;
+}

--- a/src/RwFramework/GSyst.h
+++ b/src/RwFramework/GSyst.h
@@ -8,6 +8,9 @@
 \author   Costas Andreopoulos <costas.andreopoulos \at stfc.ac.uk>
           University of Liverpool & STFC Rutherford Appleton Lab
 
+          Steven Gardiner <gardiner \at fnal.gov>
+          Fermi National Accelerator Laboratory
+
 \created  Aug 1, 2009
 
 \cpright  Copyright (c) 2003-2018, The GENIE Collaboration
@@ -18,6 +21,7 @@
 #ifndef _G_SYSTEMATIC_PARAM_H_
 #define _G_SYSTEMATIC_PARAM_H_
 
+#include <map>
 #include <string>
 
 // GENIE/Generator includes
@@ -36,10 +40,6 @@ typedef enum EGSyst {
 
   //
   // Neutrino cross section systematics
-  //
-  // Note:
-  //
-  //
   //
 
   // NCEL tweaking parameters:
@@ -105,13 +105,11 @@ typedef enum EGSyst {
   kHadrAGKYTwkDial_xF1pi,         ///< tweak xF distribution for low multiplicity (N + pi) DIS f/s produced by AGKY
   kHadrAGKYTwkDial_pT1pi,         ///< tweak pT distribution for low multiplicity (N + pi) DIS f/s produced by AGKY
 
-
   //
   // Medium-effects to hadronization
   //
 
   kHadrNuclTwkDial_FormZone,         ///< tweak formation zone
-
 
   //
   // Intranuclear rescattering systematics.
@@ -161,7 +159,6 @@ typedef enum EGSyst {
   kXSecTwkDial_ZExpA4CCQE,        ///< tweak Z-expansion coefficient 4, affects dsigma(CCQE)/dQ2 both in shape and normalization
   kXSecTwkDial_AxFFCCQEshape,     ///< tweak axial nucleon form factors (dipole -> z-expansion) - shape only effect of dsigma(CCQE)/dQ2
 
-
   //
   //   Alternative approach to CCQE form factors (RunningMA)
   //
@@ -169,7 +166,9 @@ typedef enum EGSyst {
   kXSecTwkDial_E0CCQEshape,       ///< tweak E0 CCQE RunningMA, affects dsigma(CCQE)/dQ2 in shape only (normalized to constant integral)
   kXSecTwkDial_E0CCQE,            ///< tweak E0 CCQE RunningMA, affects dsigma(CCQE)/dQ2 both in shape and normalization
 
-  /// EmpiricalMEC dials
+  //
+  // Empirical MEC dials
+  //
   kXSecTwkDial_EmpMEC_Mq2d,
   kXSecTwkDial_EmpMEC_Mass,
   kXSecTwkDial_EmpMEC_Width,
@@ -191,200 +190,33 @@ typedef enum EGSyst {
 
 
 class GSyst {
+
 public:
  //......................................................................................
- static string AsString(GSyst_t syst)
- {
-   switch(syst) {
-     case ( kXSecTwkDial_MaNCEL           ) : return "MaNCEL";               break;
-     case ( kXSecTwkDial_EtaNCEL          ) : return "EtaNCEL";              break;
-     case ( kXSecTwkDial_NormCCQE         ) : return "NormCCQE";             break;
-     case ( kXSecTwkDial_NormCCQEenu      ) : return "NormCCQEenu";          break;
-     case ( kXSecTwkDial_MaCCQE           ) : return "MaCCQE";               break;
-     case ( kXSecTwkDial_MaCCQEshape      ) : return "MaCCQEshape";          break;
-     case ( kXSecTwkDial_E0CCQE           ) : return "E0CCQE";               break;
-     case ( kXSecTwkDial_E0CCQEshape      ) : return "E0CCQEshape";          break;
-     case ( kXSecTwkDial_ZNormCCQE        ) : return "ZNormCCQE";            break;
-     case ( kXSecTwkDial_ZExpA1CCQE       ) : return "ZExpA1CCQE";           break;
-     case ( kXSecTwkDial_ZExpA2CCQE       ) : return "ZExpA2CCQE";           break;
-     case ( kXSecTwkDial_ZExpA3CCQE       ) : return "ZExpA3CCQE";           break;
-     case ( kXSecTwkDial_ZExpA4CCQE       ) : return "ZExpA4CCQE";           break;
-     case ( kXSecTwkDial_AxFFCCQEshape    ) : return "AxFFCCQEshape";        break;
-     case ( kXSecTwkDial_VecFFCCQEshape   ) : return "VecFFCCQEshape";       break;
-     case ( kXSecTwkDial_NormCCRES        ) : return "NormCCRES";            break;
-     case ( kXSecTwkDial_MaCCRESshape     ) : return "MaCCRESshape";         break;
-     case ( kXSecTwkDial_MvCCRESshape     ) : return "MvCCRESshape";         break;
-     case ( kXSecTwkDial_MaCCRES          ) : return "MaCCRES";              break;
-     case ( kXSecTwkDial_MvCCRES          ) : return "MvCCRES";              break;
-     case ( kXSecTwkDial_NormNCRES        ) : return "NormNCRES";            break;
-     case ( kXSecTwkDial_MaNCRESshape     ) : return "MaNCRESshape";         break;
-     case ( kXSecTwkDial_MvNCRESshape     ) : return "MvNCRESshape";         break;
-     case ( kXSecTwkDial_MaNCRES          ) : return "MaNCRES";              break;
-     case ( kXSecTwkDial_MvNCRES          ) : return "MvNCRES";              break;
-     case ( kXSecTwkDial_MaCOHpi          ) : return "MaCOHpi";              break;
-     case ( kXSecTwkDial_R0COHpi          ) : return "R0COHpi";              break;
-     case ( kXSecTwkDial_RvpCC1pi         ) : return "NonRESBGvpCC1pi";      break;
-     case ( kXSecTwkDial_RvpCC2pi         ) : return "NonRESBGvpCC2pi";      break;
-     case ( kXSecTwkDial_RvpNC1pi         ) : return "NonRESBGvpNC1pi";      break;
-     case ( kXSecTwkDial_RvpNC2pi         ) : return "NonRESBGvpNC2pi";      break;
-     case ( kXSecTwkDial_RvnCC1pi         ) : return "NonRESBGvnCC1pi";      break;
-     case ( kXSecTwkDial_RvnCC2pi         ) : return "NonRESBGvnCC2pi";      break;
-     case ( kXSecTwkDial_RvnNC1pi         ) : return "NonRESBGvnNC1pi";      break;
-     case ( kXSecTwkDial_RvnNC2pi         ) : return "NonRESBGvnNC2pi";      break;
-     case ( kXSecTwkDial_RvbarpCC1pi      ) : return "NonRESBGvbarpCC1pi";   break;
-     case ( kXSecTwkDial_RvbarpCC2pi      ) : return "NonRESBGvbarpCC2pi";   break;
-     case ( kXSecTwkDial_RvbarpNC1pi      ) : return "NonRESBGvbarpNC1pi";   break;
-     case ( kXSecTwkDial_RvbarpNC2pi      ) : return "NonRESBGvbarpNC2pi";   break;
-     case ( kXSecTwkDial_RvbarnCC1pi      ) : return "NonRESBGvbarnCC1pi";   break;
-     case ( kXSecTwkDial_RvbarnCC2pi      ) : return "NonRESBGvbarnCC2pi";   break;
-     case ( kXSecTwkDial_RvbarnNC1pi      ) : return "NonRESBGvbarnNC1pi";   break;
-     case ( kXSecTwkDial_RvbarnNC2pi      ) : return "NonRESBGvbarnNC2pi";   break;
-     case ( kXSecTwkDial_AhtBY            ) : return "AhtBY";                break;
-     case ( kXSecTwkDial_BhtBY            ) : return "BhtBY";                break;
-     case ( kXSecTwkDial_CV1uBY           ) : return "CV1uBY";               break;
-     case ( kXSecTwkDial_CV2uBY           ) : return "CV2uBY";               break;
-     case ( kXSecTwkDial_AhtBYshape       ) : return "AhtBYshape";           break;
-     case ( kXSecTwkDial_BhtBYshape       ) : return "BhtBYshape";           break;
-     case ( kXSecTwkDial_CV1uBYshape      ) : return "CV1uBYshape";          break;
-     case ( kXSecTwkDial_CV2uBYshape      ) : return "CV2uBYshape";          break;
-     case ( kXSecTwkDial_NormDISCC        ) : return "NormDISCC";            break;
-     case ( kXSecTwkDial_RnubarnuCC       ) : return "RnubarnuCC";           break;
-     case ( kXSecTwkDial_DISNuclMod       ) : return "DISNuclMod";           break;
-     case ( kXSecTwkDial_NC               ) : return "NC";                   break;
-     case ( kHadrAGKYTwkDial_xF1pi        ) : return "AGKYxF1pi";            break;
-     case ( kHadrAGKYTwkDial_pT1pi        ) : return "AGKYpT1pi";            break;
-     case ( kHadrNuclTwkDial_FormZone     ) : return "FormZone";             break;
-     case ( kINukeTwkDial_MFP_pi          ) : return "MFP_pi";               break;
-     case ( kINukeTwkDial_MFP_N           ) : return "MFP_N";                break;
-     case ( kINukeTwkDial_FrCEx_pi        ) : return "FrCEx_pi";             break;
-       //     case ( kINukeTwkDial_FrElas_pi       ) : return "FrElas_pi";            break;
-     case ( kINukeTwkDial_FrInel_pi       ) : return "FrInel_pi";            break;
-     case ( kINukeTwkDial_FrAbs_pi        ) : return "FrAbs_pi";             break;
-     case ( kINukeTwkDial_FrPiProd_pi     ) : return "FrPiProd_pi";          break;
-     case ( kINukeTwkDial_FrCEx_N         ) : return "FrCEx_N";              break;
-       //     case ( kINukeTwkDial_FrElas_N        ) : return "FrElas_N";             break;
-     case ( kINukeTwkDial_FrInel_N        ) : return "FrInel_N";             break;
-     case ( kINukeTwkDial_FrAbs_N         ) : return "FrAbs_N";              break;
-     case ( kINukeTwkDial_FrPiProd_N      ) : return "FrPiProd_N";           break;
-     case ( kSystNucl_CCQEPauliSupViaKF   ) : return "CCQEPauliSupViaKF";    break;
-     case ( kSystNucl_CCQEMomDistroFGtoSF ) : return "CCQEMomDistroFGtoSF";  break;
-     case ( kRDcyTwkDial_BR1gamma         ) : return "RDecBR1gamma";         break;
-     case ( kRDcyTwkDial_BR1eta           ) : return "RDecBR1eta";           break;
-     case ( kRDcyTwkDial_Theta_Delta2Npi  ) : return "Theta_Delta2Npi";      break;
-     case ( kXSecTwkDial_EmpMEC_Mq2d      ) : return "EmpMEC_Mq2d";          break;
-     case ( kXSecTwkDial_EmpMEC_Mass      ) : return "EmpMEC_Mass";          break;
-     case ( kXSecTwkDial_EmpMEC_Width     ) : return "EmpMEC_Width";         break;
-     case ( kXSecTwkDial_EmpMEC_FracPN_NC ) : return "EmpMEC_FracPN_NC";     break;
-     case ( kXSecTwkDial_EmpMEC_FracPN_CC ) : return "EmpMEC_FracPN_CC";     break;
-     case ( kXSecTwkDial_EmpMEC_FracCCQE  ) : return "EmpMEC_FracCCQE";      break;
-     case ( kXSecTwkDial_EmpMEC_FracNCQE  ) : return "EmpMEC_FracNCQE";      break;
-     case ( kXSecTwkDial_EmpMEC_FracPN_EM ) : return "EmpMEC_FracPN_EM";     break;
-     case ( kXSecTwkDial_EmpMEC_FracEMQE  ) : return "EmpMEC_FracEMQE";      break;
-
-     default:
-       return "-";
-   }
-   return "";
+ static string AsString(GSyst_t syst) {
+   // Convert the GSyst_t value into its corresponding string by looking it
+   // up in the map.
+   std::map<GSyst_t, string>::const_iterator it = fGSystToStringMap.find( syst );
+   if ( it != fGSystToStringMap.cend() ) return it->second;
+   // If a match could not be found, then return "-".
+   else return "-";
  }
  //......................................................................................
- static GSyst_t FromString(string syst)
- {
-   const GSyst_t systematics[] =
-   {
-       kXSecTwkDial_MaNCEL,
-       kXSecTwkDial_EtaNCEL,
-       kXSecTwkDial_NormCCQE,
-       kXSecTwkDial_NormCCQEenu,
-       kXSecTwkDial_MaCCQE,
-       kXSecTwkDial_MaCCQEshape,
-       kXSecTwkDial_E0CCQE,
-       kXSecTwkDial_E0CCQEshape,
-       kXSecTwkDial_ZNormCCQE,
-       kXSecTwkDial_ZExpA1CCQE,
-       kXSecTwkDial_ZExpA2CCQE,
-       kXSecTwkDial_ZExpA3CCQE,
-       kXSecTwkDial_ZExpA4CCQE,
-       kXSecTwkDial_AxFFCCQEshape,
-       kXSecTwkDial_VecFFCCQEshape,
-       kXSecTwkDial_NormCCRES,
-       kXSecTwkDial_MaCCRESshape,
-       kXSecTwkDial_MvCCRESshape,
-       kXSecTwkDial_MaCCRES,
-       kXSecTwkDial_MvCCRES,
-       kXSecTwkDial_NormNCRES,
-       kXSecTwkDial_MaNCRESshape,
-       kXSecTwkDial_MvNCRESshape,
-       kXSecTwkDial_MaNCRES,
-       kXSecTwkDial_MvNCRES,
-       kXSecTwkDial_MaCOHpi,
-       kXSecTwkDial_R0COHpi,
-       kXSecTwkDial_RvpCC1pi,
-       kXSecTwkDial_RvpCC2pi,
-       kXSecTwkDial_RvpNC1pi,
-       kXSecTwkDial_RvpNC2pi,
-       kXSecTwkDial_RvnCC1pi,
-       kXSecTwkDial_RvnCC2pi,
-       kXSecTwkDial_RvnNC1pi,
-       kXSecTwkDial_RvnNC2pi,
-       kXSecTwkDial_RvbarpCC1pi,
-       kXSecTwkDial_RvbarpCC2pi,
-       kXSecTwkDial_RvbarpNC1pi,
-       kXSecTwkDial_RvbarpNC2pi,
-       kXSecTwkDial_RvbarnCC1pi,
-       kXSecTwkDial_RvbarnCC2pi,
-       kXSecTwkDial_RvbarnNC1pi,
-       kXSecTwkDial_RvbarnNC2pi,
-       kXSecTwkDial_AhtBY,
-       kXSecTwkDial_BhtBY,
-       kXSecTwkDial_CV1uBY,
-       kXSecTwkDial_CV2uBY,
-       kXSecTwkDial_AhtBYshape,
-       kXSecTwkDial_BhtBYshape,
-       kXSecTwkDial_CV1uBYshape,
-       kXSecTwkDial_CV2uBYshape,
-       kXSecTwkDial_NormDISCC,
-       kXSecTwkDial_RnubarnuCC,
-       kXSecTwkDial_DISNuclMod,
-       kHadrAGKYTwkDial_xF1pi,
-       kHadrAGKYTwkDial_pT1pi,
-       kHadrNuclTwkDial_FormZone,
-       kINukeTwkDial_MFP_pi,
-       kINukeTwkDial_MFP_N,
-       kINukeTwkDial_FrCEx_pi,
-       //       kINukeTwkDial_FrElas_pi,
-       kINukeTwkDial_FrInel_pi,
-       kINukeTwkDial_FrAbs_pi,
-       kINukeTwkDial_FrPiProd_pi,
-       kINukeTwkDial_FrCEx_N,
-       //       kINukeTwkDial_FrElas_N,
-       kINukeTwkDial_FrInel_N,
-       kINukeTwkDial_FrAbs_N,
-       kINukeTwkDial_FrPiProd_N,
-       kSystNucl_CCQEPauliSupViaKF,
-       kSystNucl_CCQEMomDistroFGtoSF,
-       kRDcyTwkDial_BR1gamma,
-       kRDcyTwkDial_BR1eta,
-       kRDcyTwkDial_Theta_Delta2Npi,
-       kXSecTwkDial_EmpMEC_Mq2d,
-       kXSecTwkDial_EmpMEC_Mass,
-       kXSecTwkDial_EmpMEC_Width,
-       kXSecTwkDial_EmpMEC_FracPN_NC,
-       kXSecTwkDial_EmpMEC_FracPN_CC,
-       kXSecTwkDial_EmpMEC_FracCCQE,
-       kXSecTwkDial_EmpMEC_FracNCQE,
-       kXSecTwkDial_EmpMEC_FracPN_EM,
-       kXSecTwkDial_EmpMEC_FracEMQE,
-       kNullSystematic
-   };
-
-   int isyst=0;
-   while(systematics[isyst]!=kNullSystematic) {
-     if( AsString(systematics[isyst]) == syst ) {
-        return systematics[isyst];
-     }
-     isyst++;
+ static GSyst_t FromString(string syst_name) {
+   // This search could be simplified a bit in C++11 (e.g., using std::find_if
+   // and a lambda). Perhaps we could tweak it for GENIE 4. - S. Gardiner
+   std::map<GSyst_t, string>::const_iterator it = fGSystToStringMap.cbegin();
+   std::map<GSyst_t, string>::const_iterator end = fGSystToStringMap.cend();
+   while ( it != end ) {
+     // If the value stored in the map (i.e., the string containing the
+     // systematic tweak knob name) matches the input string, return the
+     // corresponding key (GSyst_t value)
+     if ( it->second == syst_name ) return it->first;
+     ++it;
    }
 
+   // A matching string could not be found in the map, so just return the null
+   // enum value
    return kNullSystematic;
  }
  //......................................................................................
@@ -592,6 +424,15 @@ public:
    return kNullSystematic;
  }
  //......................................................................................
+
+private:
+
+  /// Map that defines conversions between GSyst_t values and their string
+  /// representations
+  static std::map<GSyst_t, std::string> fGSystToStringMap;
+
+  /// Helper function to initialize the GSyst_t <-> std::string conversion map
+  static std::map<GSyst_t, std::string> BuildGSystToStringMap();
 
 };
 

--- a/src/RwFramework/GSystUncertainty.cxx
+++ b/src/RwFramework/GSystUncertainty.cxx
@@ -8,10 +8,17 @@
 
           Costas Andreopoulos <costas.andreopoulos \at stfc.ac.uk>
           University of Liverpool & STFC Rutherford Appleton Lab
+
+          Steven Gardiner <gardiner \at fnal.gov>
+          Fermi National Accelerator Laboratory
 */
 //____________________________________________________________________________
 
+#include <cstdlib>
+
 // GENIE/Generator includes
+#include "Framework/Algorithm/AlgConfigPool.h"
+#include "Framework/Algorithm/AlgFactory.h"
 #include "Framework/Messenger/Messenger.h"
 
 // GENIE/Reweight includes
@@ -46,120 +53,51 @@ GSystUncertainty * GSystUncertainty::Instance()
 //____________________________________________________________________________
 double GSystUncertainty::OneSigmaErr(GSyst_t s, int sign) const
 {
-  if(sign > 0) {
-    map<GSyst_t,double>::const_iterator it = fOneSigPlusErrMap.find(s);
-    if(it != fOneSigPlusErrMap.end()) return it->second;
-    return 0;
-  } 
-  else 
-  if(sign < 0) {
-    map<GSyst_t,double>::const_iterator it = fOneSigMnusErrMap.find(s);
-    if(it != fOneSigMnusErrMap.end()) return it->second;
-    return 0;
-  } 
-  else {
-    // Handle default argument (sign=0)
-    // Case added for compatibility purposes since most existing weight 
-    // calcutators call GSystUncertainty::OneSigmaErr(GSyst_t) and the error 
-    // on most GSyst_t params is symmetric.
-    double err = 0.5 * (
-        this->OneSigmaErr(s, +1) + this->OneSigmaErr(s, -1));
-    return err;
-  }
+  const std::map<GSyst_t, GSystUncertaintyTable::MapEntry>&
+    error_map = fTable->GetErrorsMap();
+
+  // Search the map for the uncertainties associated with this
+  // tweak dial. If we couldn't find an entry, then just
+  // return zero.
+  std::map<GSyst_t, GSystUncertaintyTable::MapEntry>::const_iterator
+    it = error_map.find( s );
+  if ( it == error_map.end() ) return 0.;
+
+  // Otherwise, get the appropriate one-sigma error
+  // (plus, minus, or the mean of the two)
+  if (sign > 0) return it->second.PlusOneSigmaErr();
+  else if (sign < 0) return it->second.MinusOneSigmaErr();
+
+  // Handle default argument (sign=0)
+  // Case added for compatibility purposes since most existing weight
+  // calcutators call GSystUncertainty::OneSigmaErr(GSyst_t) and the error
+  // on most GSyst_t params is symmetric.
+  double plus_err = it->second.PlusOneSigmaErr();
+  double minus_err = it->second.MinusOneSigmaErr();
+  double err = 0.5 * (plus_err + minus_err);
+  return err;
 }
 //____________________________________________________________________________
 void GSystUncertainty::SetUncertainty(
    GSyst_t s, double plus_err, double minus_err)
 {
-  //fOneSigPlusErrMap.insert( map<GSyst_t,double>::value_type(s, plus_err ) );
-  //fOneSigMnusErrMap.insert( map<GSyst_t,double>::value_type(s, minus_err) );
-  fOneSigPlusErrMap[s] = plus_err;
-  fOneSigMnusErrMap[s] =  minus_err;
+  std::map<GSyst_t, GSystUncertaintyTable::MapEntry>&
+    error_map = (*fTable->GetErrorsMapPtr());
+
+  std::string knob_name = GSyst::AsString( s );
+
+  LOG("ReW", pINFO) << "Setting uncertainties for"
+    << " Reweight tweak dial " << knob_name << " to +"
+    << plus_err << ", -" << minus_err;
+
+  error_map[s] = GSystUncertaintyTable::MapEntry(plus_err, minus_err);
 }
 //____________________________________________________________________________
 void GSystUncertainty::SetDefaults(void)
 {
-  this->SetUncertainty( kXSecTwkDial_MaNCEL,         0.25, 0.25);
-  this->SetUncertainty( kXSecTwkDial_EtaNCEL,        0.30, 0.30);
-  this->SetUncertainty( kXSecTwkDial_NormCCQE,       0.20, 0.15);
-  //changed according to best fit, see https://indico.fnal.gov/event/11610/session/18/contribution/14
-  this->SetUncertainty( kXSecTwkDial_MaCCQEshape,    0.025, 0.025);
-  this->SetUncertainty( kXSecTwkDial_MaCCQE,         0.03, 0.03);     
-  
-  this->SetUncertainty( kXSecTwkDial_E0CCQEshape,    0.18, 0.16);
-  this->SetUncertainty( kXSecTwkDial_E0CCQE,         0.18, 0.16);
-  this->SetUncertainty( kXSecTwkDial_ZNormCCQE,      0.20, 0.15);
-  this->SetUncertainty( kXSecTwkDial_ZExpA1CCQE,     0.14, 0.14);
-  this->SetUncertainty( kXSecTwkDial_ZExpA2CCQE,     0.67, 0.67);
-  this->SetUncertainty( kXSecTwkDial_ZExpA3CCQE,     1.00, 1.00);
-  this->SetUncertainty( kXSecTwkDial_ZExpA4CCQE,     0.75, 0.75);
-  this->SetUncertainty( kXSecTwkDial_NormCCRES,      0.20, 0.20);
-  this->SetUncertainty( kXSecTwkDial_MaCCRESshape,   0.10, 0.10);
-  this->SetUncertainty( kXSecTwkDial_MvCCRESshape,   0.05, 0.05);
-  this->SetUncertainty( kXSecTwkDial_MaCCRES,        0.20, 0.20);
-  this->SetUncertainty( kXSecTwkDial_MvCCRES,        0.10, 0.10);
-  this->SetUncertainty( kXSecTwkDial_NormNCRES,      0.20, 0.20);
-  this->SetUncertainty( kXSecTwkDial_MaNCRESshape,   0.10, 0.10);
-  this->SetUncertainty( kXSecTwkDial_MvNCRESshape,   0.05, 0.05);
-  this->SetUncertainty( kXSecTwkDial_MaNCRES,        0.20, 0.20);
-  this->SetUncertainty( kXSecTwkDial_MvNCRES,        0.10, 0.10);
-  this->SetUncertainty( kXSecTwkDial_MaCOHpi,        0.40, 0.40);
-  this->SetUncertainty( kXSecTwkDial_R0COHpi,        0.10, 0.10);
-  this->SetUncertainty( kXSecTwkDial_RvpCC1pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvpCC2pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvpNC1pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvpNC2pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvnCC1pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvnCC2pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvnNC1pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvnNC2pi,       0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarpCC1pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarpCC2pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarpNC1pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarpNC2pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarnCC1pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarnCC2pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarnNC1pi,    0.50, 0.50);
-  this->SetUncertainty( kXSecTwkDial_RvbarnNC2pi,    0.50, 0.50);
-
-  // From Debdatta's thesis: 
-  //   Aht  = 0.538 +/- 0.134	
-  //   Bht  = 0.305 +/- 0.076
-  //   CV1u = 0.291 +/- 0.087
-  //   CV2u = 0.189 +/- 0.076
-
-  this->SetUncertainty( kXSecTwkDial_AhtBY,          0.25, 0.25);
-  this->SetUncertainty( kXSecTwkDial_BhtBY,          0.25, 0.25);
-  this->SetUncertainty( kXSecTwkDial_CV1uBY,         0.30, 0.30);
-  this->SetUncertainty( kXSecTwkDial_CV2uBY,         0.40, 0.40);
-
-  this->SetUncertainty( kXSecTwkDial_AhtBYshape,     0.25, 0.25);
-  this->SetUncertainty( kXSecTwkDial_BhtBYshape,     0.25, 0.25);
-  this->SetUncertainty( kXSecTwkDial_CV1uBYshape,    0.30, 0.30);
-  this->SetUncertainty( kXSecTwkDial_CV2uBYshape,    0.40, 0.40);
-
-  this->SetUncertainty( kXSecTwkDial_DISNuclMod,     1.00, 1.00);
-  this->SetUncertainty( kSystNucl_CCQEPauliSupViaKF, 0.30, 0.30);
-  this->SetUncertainty( kHadrAGKYTwkDial_xF1pi,      0.20, 0.20);
-  this->SetUncertainty( kHadrAGKYTwkDial_pT1pi,      0.03, 0.03);
-  this->SetUncertainty( kHadrNuclTwkDial_FormZone,   0.50, 0.50);
-
-  // From INTRANUKE pi+A and N+A mode comparisons with hadron scattering data:
-  //
-  this->SetUncertainty( kINukeTwkDial_MFP_pi,        0.20, 0.20);
-  this->SetUncertainty( kINukeTwkDial_MFP_N,         0.20, 0.20);
-  this->SetUncertainty( kINukeTwkDial_FrCEx_pi,      0.50, 0.50);
-  //  this->SetUncertainty( kINukeTwkDial_FrElas_pi,     0.10, 0.10);
-  this->SetUncertainty( kINukeTwkDial_FrInel_pi,     0.40, 0.40);
-  this->SetUncertainty( kINukeTwkDial_FrAbs_pi,      0.30, 0.30);
-  this->SetUncertainty( kINukeTwkDial_FrPiProd_pi,   0.20, 0.20);
-  this->SetUncertainty( kINukeTwkDial_FrCEx_N,       0.50, 0.50);
-  //  this->SetUncertainty( kINukeTwkDial_FrElas_N,      0.30, 0.30);
-  this->SetUncertainty( kINukeTwkDial_FrInel_N,      0.40, 0.40);
-  this->SetUncertainty( kINukeTwkDial_FrAbs_N,       0.20, 0.20);
-  this->SetUncertainty( kINukeTwkDial_FrPiProd_N,    0.20, 0.20);
-
-  this->SetUncertainty( kRDcyTwkDial_BR1gamma,       0.50, 0.50);
-  this->SetUncertainty( kRDcyTwkDial_BR1eta,         0.50, 0.50);
+  AlgFactory* alg_f = AlgFactory::Instance();
+  fTable = dynamic_cast< GSystUncertaintyTable* >(
+    alg_f->AdoptAlgorithm("genie::rew::GSystUncertaintyTable", "Default"));
+  assert( fTable );
 }
 //____________________________________________________________________________

--- a/src/RwFramework/GSystUncertainty.h
+++ b/src/RwFramework/GSystUncertainty.h
@@ -3,13 +3,16 @@
 
 \class    genie::rew::GSystUncertainty
 
-\brief    
+\brief    Singleton class for looking up reweight tweak dial uncertainties
 
 \author   Costas Andreopoulos <costas.andreopoulos \at stfc.ac.uk>
           University of Liverpool & STFC Rutherford Appleton Lab
 
           Jim Dobson <J.Dobson07 \at imperial.ac.uk>
           Imperial College London
+
+          Steven Gardiner <gardiner \at fnal.gov>
+          Fermi National Accelerator Laboratory
 
 \created  Sep 1, 2009
 
@@ -25,6 +28,7 @@
 
 // GENIE/Reweight includes
 #include "RwFramework/GSyst.h"
+#include "RwFramework/GSystUncertaintyTable.h"
 
 using std::map;
 
@@ -33,7 +37,8 @@ namespace rew   {
 
 class GSystUncertainty {
 
-public:  
+public:
+
   static GSystUncertainty * Instance (void);
 
   double OneSigmaErr    (GSyst_t syst, int sign=0) const;
@@ -41,16 +46,15 @@ public:
 
 private:
 
+  GSystUncertaintyTable* fTable;
+
   void SetDefaults(void);
 
-  map<GSyst_t, double> fOneSigPlusErrMap; // + err
-  map<GSyst_t, double> fOneSigMnusErrMap; // - err
-
   GSystUncertainty();
-  GSystUncertainty(const GSystUncertainty & err);
+  GSystUncertainty(const GSystUncertainty& err);
  ~GSystUncertainty();
-  
-  static GSystUncertainty * fInstance;
+
+  static GSystUncertainty* fInstance;
 
   struct Cleaner {
       void DummyMethodAndSilentCompiler() { }
@@ -67,5 +71,4 @@ private:
 } // rew   namespace
 } // genie namespace
 
-#endif 
-
+#endif

--- a/src/RwFramework/GSystUncertaintyTable.cxx
+++ b/src/RwFramework/GSystUncertaintyTable.cxx
@@ -1,0 +1,90 @@
+//____________________________________________________________________________
+/*
+ Copyright (c) 2003-2019, The GENIE Collaboration
+ For the full text of the license visit http://copyright.genie-mc.org
+ or see $GENIE/LICENSE
+
+ Author: Steven Gardiner <gardiner \at fnal.gov>
+         Fermi National Accelerator Laboratory
+
+ For the class documentation see the corresponding header file.
+*/
+//____________________________________________________________________________
+
+#include "Framework/Algorithm/AlgConfigPool.h"
+#include "Framework/Messenger/Messenger.h"
+
+#include "RwFramework/GSystUncertaintyTable.h"
+
+using namespace genie;
+using namespace genie::rew;
+
+//____________________________________________________________________________
+GSystUncertaintyTable::GSystUncertaintyTable() :
+Algorithm("genie::rew::GSystUncertaintyTable")
+{
+
+}
+//____________________________________________________________________________
+GSystUncertaintyTable::GSystUncertaintyTable(std::string config) :
+Algorithm("genie::rew::GSystUncertaintyTable", config)
+{
+
+}
+//____________________________________________________________________________
+GSystUncertaintyTable::~GSystUncertaintyTable()
+{
+
+}
+//____________________________________________________________________________
+void GSystUncertaintyTable::Configure(const Registry& config)
+{
+  Algorithm::Configure(config);
+  this->LoadConfig();
+}
+//____________________________________________________________________________
+void GSystUncertaintyTable::Configure(std::string config)
+{
+  Algorithm::Configure(config);
+  this->LoadConfig();
+}
+//____________________________________________________________________________
+void GSystUncertaintyTable::LoadConfig(void)
+{
+  // Load one-sigma uncertainties from the Registry for every defined
+  // tweak dial. If there's a missing entry, set both the plus and minus
+  // one-sigma values to zero.
+  double plus_err, minus_err;
+  int syst_knob_index = 1; // Index zero corresponds to kNullSystematic
+  int last_index = static_cast<int>( kNTwkDials );
+
+  while ( syst_knob_index < last_index ) {
+
+    GSyst_t syst_knob = static_cast<GSyst_t>( syst_knob_index );
+
+    std::string knob_name = GSyst::AsString( syst_knob );
+    if ( !knob_name.empty() && knob_name != "-") {
+      GetParamDef(knob_name + "@PlusOneSigma", plus_err, 0.);
+      GetParamDef(knob_name + "@MinusOneSigma", minus_err, 0.);
+
+      fErrorsMap[ syst_knob ] = MapEntry( plus_err, minus_err );
+
+      LOG("ReW", pNOTICE) << "Reweight parameter "
+       << knob_name << " has one-sigma uncertainties +" << plus_err
+       << ", -" << minus_err;
+    }
+    else if ( knob_name == "-" ) {
+      // This string is used for the now-invalid FrElas_N and FrElas_Pi
+      // knobs, so just ignore it
+      LOG("ReW", pNOTICE) << "Skipping deprecated tweak dial knob for "
+       << "GSyst_t enum value " << syst_knob;
+    }
+    else {
+      LOG("ReW", pWARN) << "Unrecognized"
+        << " GSyst_t value " << syst_knob << " encountered.";
+    }
+
+    ++syst_knob_index;
+  }
+
+}

--- a/src/RwFramework/GSystUncertaintyTable.h
+++ b/src/RwFramework/GSystUncertaintyTable.h
@@ -1,0 +1,83 @@
+//____________________________________________________________________________
+/*!
+
+\class    genie::GSystUncertaintyTable
+
+\brief    Algorithm that enables bi-directional 1-sigma parameter errors
+          to be configured for Reweight via XML
+
+\author   Steven Gardiner <gardiner \at fnal.gov>
+          Fermi National Accelerator Laboratory
+
+\created  September 10, 2019
+
+\cpright  Copyright (c) 2003-2019, The GENIE Collaboration
+          For the full text of the license visit http://copyright.genie-mc.org
+          or see $GENIE/LICENSE
+*/
+//____________________________________________________________________________
+
+#ifndef _G_SYST_UNCERTAINTY_TABLE_H_
+#define _G_SYST_UNCERTAINTY_TABLE_H_
+
+// Generator includes
+#include "Framework/Algorithm/Algorithm.h"
+
+// Reweight includes
+#include "RwFramework/GSyst.h"
+
+namespace genie {
+namespace rew {
+
+class GSystUncertaintyTable : public Algorithm {
+
+public:
+  GSystUncertaintyTable();
+  GSystUncertaintyTable(string config);
+  virtual ~GSystUncertaintyTable();
+
+  // Override the Algorithm::Configure methods to load configuration
+  // data in private data members
+  void Configure (const Registry & config);
+  void Configure (string param_set);
+
+  // Represents a pair of plus and minus one-sigma errors
+  // for a model parameter accessible via a Reweight tweak dial
+  class MapEntry {
+    public:
+      MapEntry() : fErrPlusOneSigma(0.), fErrMinusOneSigma(0.) {}
+      MapEntry(double plus_one_sig_err, double minus_one_sig_err)
+        : fErrPlusOneSigma( plus_one_sig_err ),
+        fErrMinusOneSigma( minus_one_sig_err ) {}
+
+      inline double PlusOneSigmaErr() const { return fErrPlusOneSigma; }
+      inline double MinusOneSigmaErr() const { return fErrMinusOneSigma; }
+
+      inline void SetPlusOneSigmaErr(double plus_err)
+        { fErrPlusOneSigma = plus_err; }
+
+      inline void SetMinusOneSigmaErr(double minus_err)
+        { fErrMinusOneSigma = minus_err; }
+
+    protected:
+      double fErrPlusOneSigma;
+      double fErrMinusOneSigma;
+  };
+
+  inline const std::map<GSyst_t, MapEntry>& GetErrorsMap() const
+    { return fErrorsMap; }
+
+  inline std::map<GSyst_t, MapEntry>* GetErrorsMapPtr() { return &fErrorsMap; }
+
+private:
+
+  void LoadConfig (void);
+
+  std::map<GSyst_t, MapEntry> fErrorsMap;
+
+};
+
+} // rew namespace
+} // genie namespace
+
+#endif //_G_SYST_UNCERTAINTY_TABLE_H_

--- a/src/RwFramework/LinkDef.h
+++ b/src/RwFramework/LinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class genie::rew::GSystSet;
 #pragma link C++ class genie::rew::GSystInfo;
 #pragma link C++ class genie::rew::GSystUncertainty;
+#pragma link C++ class genie::rew::GSystUncertaintyTable;
 #pragma link C++ class genie::rew::GReWeight;
 
 #pragma link C++ ioctortype TRootIOCtor;


### PR DESCRIPTION
This is intended as a short-term step toward a more flexible design allowing tune-dependent uncertainties, retrieval and use of the covariance matrix for the tuned parameters, etc. Marco and I have begun discussing some of those design considerations, but they will take some time to get right. In the meantime, simply having configurable ±1-sigma uncertainties will be helpful to users.

All public interfaces of GSystUncertainty remain unchanged, despite some big changes "under the hood" in this pull request.

The static methods in GSyst that convert between GSyst_t and std::string have also been updated to avoid redundancy. A single private std::map is now used to manage bidirectional conversions.

See GENIE-MC/Generator#59 for the corresponding changes (XML configuration only) in Generator.