### PR TITLE
Fix/rootcling_failure_missed_fwd_INuke

### DIFF
--- a/src/RwCalculators/GReWeightINuke.h
+++ b/src/RwCalculators/GReWeightINuke.h
@@ -48,6 +48,7 @@ class TLorentzVector;
 namespace genie {
 
  class HAIntranuke2018;
+ class GHepParticle;
 
 namespace rew   {
 


### PR DESCRIPTION
Adds missing forward declaration that caused rootcling to throw a wobbly on undeclared class.