### PR TITLE
PROFRW - Refactor AppliesTo interface to take const EventRecord &

### DIFF
--- a/src/RwCalculators/GReWeightAGKY.cxx
+++ b/src/RwCalculators/GReWeightAGKY.cxx
@@ -70,8 +70,9 @@ bool GReWeightAGKY::IsHandled(GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightAGKY::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightAGKY::AppliesTo (const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScDeepInelastic) {
     return true;
   }

--- a/src/RwCalculators/GReWeightAGKY.h
+++ b/src/RwCalculators/GReWeightAGKY.h
@@ -43,7 +43,7 @@ namespace rew   {
   ~GReWeightAGKY();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightDISNuclMod.cxx
+++ b/src/RwCalculators/GReWeightDISNuclMod.cxx
@@ -45,8 +45,9 @@ bool GReWeightDISNuclMod::IsHandled (GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightDISNuclMod::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightDISNuclMod::AppliesTo (const EventRecord &event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScDeepInelastic) {
     return true;
   }

--- a/src/RwCalculators/GReWeightDISNuclMod.h
+++ b/src/RwCalculators/GReWeightDISNuclMod.h
@@ -37,7 +37,7 @@ namespace rew   {
   ~GReWeightDISNuclMod();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightDeltaradAngle.cxx
+++ b/src/RwCalculators/GReWeightDeltaradAngle.cxx
@@ -56,8 +56,9 @@ bool GReWeightDeltaradAngle::IsHandled(GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightDeltaradAngle::AppliesTo(ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightDeltaradAngle::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if ( type == kScResonant) return true;
   return false;
 }

--- a/src/RwCalculators/GReWeightDeltaradAngle.h
+++ b/src/RwCalculators/GReWeightDeltaradAngle.h
@@ -43,7 +43,7 @@ namespace rew   {
   ~GReWeightDeltaradAngle();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightFGM.cxx
+++ b/src/RwCalculators/GReWeightFGM.cxx
@@ -61,8 +61,9 @@ bool GReWeightFGM::IsHandled(GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightFGM::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightFGM::AppliesTo (const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   switch (type) {
     case kScCoherentProduction:
     case kScDiffractive:

--- a/src/RwCalculators/GReWeightFGM.h
+++ b/src/RwCalculators/GReWeightFGM.h
@@ -48,7 +48,7 @@ namespace rew   {
   ~GReWeightFGM();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightFZone.cxx
+++ b/src/RwCalculators/GReWeightFZone.cxx
@@ -59,8 +59,9 @@ bool GReWeightFZone::IsHandled(GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightFZone::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightFZone::AppliesTo (const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScDeepInelastic) {
     return true;
   }

--- a/src/RwCalculators/GReWeightFZone.h
+++ b/src/RwCalculators/GReWeightFZone.h
@@ -40,7 +40,7 @@ namespace rew   {
   ~GReWeightFZone();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightINuke.cxx
+++ b/src/RwCalculators/GReWeightINuke.cxx
@@ -123,8 +123,9 @@ bool GReWeightINuke::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightINuke::AppliesTo(ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightINuke::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   switch (type) {
     case kScCoherentProduction:
     case kScDiffractive:

--- a/src/RwCalculators/GReWeightINuke.h
+++ b/src/RwCalculators/GReWeightINuke.h
@@ -59,7 +59,7 @@ namespace rew   {
   ~GReWeightINuke();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightModel.h
+++ b/src/RwCalculators/GReWeightModel.h
@@ -34,7 +34,7 @@ namespace rew   {
   ~GReWeightModel();
 
   //! does the current weight calculator handle this type of event?
-  virtual bool AppliesTo (ScatteringType_t type, bool is_cc) const = 0;
+  virtual bool AppliesTo (const EventRecord & event) const = 0;
 
   //! does the current weight calculator handle the input nuisance param?
   virtual bool IsHandled (GSyst_t syst) const = 0;

--- a/src/RwCalculators/GReWeightNonResonanceBkg.cxx
+++ b/src/RwCalculators/GReWeightNonResonanceBkg.cxx
@@ -77,8 +77,9 @@ bool GReWeightNonResonanceBkg::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNonResonanceBkg::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightNonResonanceBkg::AppliesTo (const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScDeepInelastic) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNonResonanceBkg.h
+++ b/src/RwCalculators/GReWeightNonResonanceBkg.h
@@ -24,6 +24,7 @@
 #include <map>
 
 // GENIE/Reweight includes
+#include "Framework/EventGen/EventRecord.h"
 #include "RwCalculators/GReWeightModel.h"
 
 namespace genie {
@@ -36,7 +37,7 @@ namespace rew   {
   ~GReWeightNonResonanceBkg();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecCCQE.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQE.cxx
@@ -157,8 +157,10 @@ bool GReWeightNuXSecCCQE::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecCCQE::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecCCQE::AppliesTo(const EventRecord &event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScQuasiElastic && is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecCCQE.h
+++ b/src/RwCalculators/GReWeightNuXSecCCQE.h
@@ -53,7 +53,7 @@ namespace rew   {
   ~GReWeightNuXSecCCQE();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord &event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEaxial.cxx
@@ -71,8 +71,10 @@ bool GReWeightNuXSecCCQEaxial::IsHandled(GSyst_t syst) const
    return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecCCQEaxial::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecCCQEaxial::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScQuasiElastic && is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecCCQEaxial.h
+++ b/src/RwCalculators/GReWeightNuXSecCCQEaxial.h
@@ -46,7 +46,7 @@ namespace rew   {
   ~GReWeightNuXSecCCQEaxial();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCQEvec.cxx
@@ -71,8 +71,10 @@ bool GReWeightNuXSecCCQEvec::IsHandled(GSyst_t syst) const
    return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecCCQEvec::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecCCQEvec::AppliesTo(const EventRecord &event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScQuasiElastic && is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecCCQEvec.h
+++ b/src/RwCalculators/GReWeightNuXSecCCQEvec.h
@@ -28,6 +28,8 @@
 #include <string>
 
 // GENIE/Reweight includes
+#include "Framework/EventGen/EventRecord.h"
+#include "Physics/XSectionIntegration/XSecIntegratorI.h"
 #include "RwCalculators/GReWeightModel.h"
 
 
@@ -47,7 +49,7 @@ namespace rew   {
   ~GReWeightNuXSecCCQEvec();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord &event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecCCRES.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCRES.cxx
@@ -101,8 +101,10 @@ bool GReWeightNuXSecCCRES::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecCCRES::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecCCRES::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScResonant && is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecCCRES.h
+++ b/src/RwCalculators/GReWeightNuXSecCCRES.h
@@ -49,7 +49,7 @@ namespace rew   {
   ~GReWeightNuXSecCCRES();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecCOH.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCOH.cxx
@@ -74,8 +74,9 @@ bool GReWeightNuXSecCOH::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecCOH::AppliesTo(ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightNuXSecCOH::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScCoherentProduction) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecCOH.h
+++ b/src/RwCalculators/GReWeightNuXSecCOH.h
@@ -41,7 +41,7 @@ namespace rew   {
   ~GReWeightNuXSecCOH();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecDIS.cxx
+++ b/src/RwCalculators/GReWeightNuXSecDIS.cxx
@@ -99,8 +99,9 @@ bool GReWeightNuXSecDIS::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecDIS::AppliesTo(ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightNuXSecDIS::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScDeepInelastic) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecDIS.h
+++ b/src/RwCalculators/GReWeightNuXSecDIS.h
@@ -47,7 +47,7 @@ namespace rew   {
   ~GReWeightNuXSecDIS();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecNC.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNC.cxx
@@ -55,8 +55,9 @@ bool GReWeightNuXSecNC::IsHandled(GSyst_t syst) const
    return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecNC::AppliesTo(ScatteringType_t /*type*/, bool is_cc) const
+bool GReWeightNuXSecNC::AppliesTo(const EventRecord & event) const
 {
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (!is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecNC.h
+++ b/src/RwCalculators/GReWeightNuXSecNC.h
@@ -37,7 +37,7 @@ namespace rew   {
   ~GReWeightNuXSecNC();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecNCEL.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCEL.cxx
@@ -74,8 +74,10 @@ bool GReWeightNuXSecNCEL::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecNCEL::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecNCEL::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScQuasiElastic && !is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecNCEL.h
+++ b/src/RwCalculators/GReWeightNuXSecNCEL.h
@@ -43,7 +43,7 @@ namespace rew   {
   ~GReWeightNuXSecNCEL();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightNuXSecNCRES.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCRES.cxx
@@ -94,8 +94,10 @@ bool GReWeightNuXSecNCRES::IsHandled(GSyst_t syst) const
    return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightNuXSecNCRES::AppliesTo(ScatteringType_t type, bool is_cc) const
+bool GReWeightNuXSecNCRES::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
+  bool is_cc = event.Summary()->ProcInfo().IsWeakCC();
   if (type==kScResonant && !is_cc) {
     return true;
   }

--- a/src/RwCalculators/GReWeightNuXSecNCRES.h
+++ b/src/RwCalculators/GReWeightNuXSecNCRES.h
@@ -45,7 +45,7 @@ namespace rew   {
   ~GReWeightNuXSecNCRES();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightResonanceDecay.cxx
+++ b/src/RwCalculators/GReWeightResonanceDecay.cxx
@@ -62,8 +62,9 @@ bool GReWeightResonanceDecay::IsHandled(GSyst_t syst) const
   return false;
 }
 //_______________________________________________________________________________________
-bool GReWeightResonanceDecay::AppliesTo (ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightResonanceDecay::AppliesTo (const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScResonant) {
     return true;
   }

--- a/src/RwCalculators/GReWeightResonanceDecay.h
+++ b/src/RwCalculators/GReWeightResonanceDecay.h
@@ -45,7 +45,7 @@ namespace rew   {
   ~GReWeightResonanceDecay();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
+++ b/src/RwCalculators/GReWeightXSecEmpiricalMEC.cxx
@@ -98,8 +98,8 @@ void GReWeightXSecEmpiricalMEC::Init(void) {
 #endif
 }
 
-bool GReWeightXSecEmpiricalMEC::AppliesTo(ScatteringType_t type,
-                                          bool /* is_cc */ ) const {
+bool GReWeightXSecEmpiricalMEC::AppliesTo(const EventRecord &event) const {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   if (type==kScMEC) { // && is_cc ?
     return true;
   }

--- a/src/RwCalculators/GReWeightXSecEmpiricalMEC.h
+++ b/src/RwCalculators/GReWeightXSecEmpiricalMEC.h
@@ -49,7 +49,7 @@ public:
   ~GReWeightXSecEmpiricalMEC();
 
   // implement the GReWeightI interface
-  bool AppliesTo(ScatteringType_t type, bool is_cc) const;
+  bool AppliesTo(const EventRecord & event) const;
   bool IsHandled(GSyst_t syst) const;
   void SetSystematic(GSyst_t syst, double val);
   void Reset(void);

--- a/src/RwCalculators/GReWeightXSecMEC.cxx
+++ b/src/RwCalculators/GReWeightXSecMEC.cxx
@@ -112,8 +112,9 @@ bool GReWeightXSecMEC::IsHandled(GSyst_t syst) const
   return handle;
 }
 //_______________________________________________________________________________________
-bool GReWeightXSecMEC::AppliesTo(ScatteringType_t type, bool /*is_cc*/) const
+bool GReWeightXSecMEC::AppliesTo(const EventRecord & event) const
 {
+  auto type = event.Summary()->ProcInfo().ScatteringTypeId();
   // Weights can be calculated for CC, NC, and EM MEC events
   if ( type == kScMEC ) return true;
   return false;

--- a/src/RwCalculators/GReWeightXSecMEC.h
+++ b/src/RwCalculators/GReWeightXSecMEC.h
@@ -39,7 +39,7 @@ namespace rew   {
   ~GReWeightXSecMEC();
 
    // implement the GReWeightI interface
-   bool   AppliesTo      (ScatteringType_t type, bool is_cc) const;
+   bool   AppliesTo      (const EventRecord & event) const;
    bool   IsHandled      (GSyst_t syst) const;
    void   SetSystematic  (GSyst_t syst, double val);
    void   Reset          (void);

--- a/src/RwFramework/GReWeightI.h
+++ b/src/RwFramework/GReWeightI.h
@@ -20,6 +20,7 @@
 
 // GENIE/Generator includes
 #include "Framework/Interaction/ScatteringType.h"
+#include "Framework/EventGen/EventRecord.h"
 
 // GENIE/Reweight includes
 #include "RwFramework/GSyst.h"
@@ -44,7 +45,7 @@ namespace rew   {
   //
   
   //! does the current weight calculator handle this type of event?
-  virtual bool AppliesTo (ScatteringType_t type, bool is_cc) const = 0; 
+  virtual bool AppliesTo (const EventRecord & event) const = 0; 
 
   //! does the current weight calculator handle the input nuisance param?
   virtual bool IsHandled (GSyst_t syst) const = 0;


### PR DESCRIPTION
Change `genie::rew::GReWeightI::AppliesTo` from `genie::rew::GReWeightI::AppliesTo(ScatteringType_t type, bool is_cc)` to `genie::rew::GReWeightI::AppliesTo(const EventRecord &)`

This will be beneficial to doing reweight based on information other than `ScatteringType_t`, e.g. by final state topology.