### PR TITLE
Fixing GReWeightResonanceDecay Double Application

### DIFF
--- a/src/Apps/gRwght1Param.cxx
+++ b/src/Apps/gRwght1Param.cxx
@@ -254,7 +254,6 @@ int main(int argc, char ** argv)
   // a few more to possibly exercise
   // rhatcher:  are there things to "fine-tune" below for these?
   rw.AdoptWghtCalc( "xsec_nc",         new GReWeightNuXSecNC        );
-  rw.AdoptWghtCalc( "res_dk",          new GReWeightResonanceDecay  );
   rw.AdoptWghtCalc( "xsec_empmec",     new GReWeightXSecEmpiricalMEC);
   rw.AdoptWghtCalc( "xsec_mec",        new GReWeightXSecMEC );
   rw.AdoptWghtCalc( "delta_rad",       new GReWeightDeltaradAngle);


### PR DESCRIPTION
@nitish-nayak and I found an issue that causes the GReWeightResonanceDecay calculator to be applied twice, leading to squared weights. `res_dk` and `hadro_res_decay` both apply the same GReWeightResonanceDecay calculator, and here I delete the `res_dk` line. This was first noticed after seeing larger than expected uncertainty for NC Delta radiative decays in MicroBooNE. The three knobs affected are BR1gamma, BR1eta, and Theta_Delta2Npi.

It seems like this code was copied, so the issue also exists in codebases for [MicroBooNE](https://cdcvs.fnal.gov/redmine/projects/ubsim/repository/revisions/v08_00_00_br/entry/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx#L605), [SBN](https://github.com/SBNSoftware/sbncode/blob/develop/sbncode/SBNEventWeight/Calculators/CrossSections/GenieWeightCalc.cxx#L590), [ANNIE](https://github.com/ANNIEsoft/ToolAnalysis/blob/c7d72255c0d80de8d64f1598dfe439e9a077fda9/UserTools/LoadReweightGenieEvent/LoadReweightGenieEvent.cpp#L1299), and [DUNE](https://internal.dunescience.org/doxygen/GenieWeightCalc_8cxx_source.html).

