### PR TITLE
Make the use of Professor2 fully optional in Reweight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,14 @@ reweight-calculators: FORCE
 prof-spline: FORCE
 	@echo " "
 	@echo "** Building GENIE/Reweight ProfSpline utilities..."
+ifeq ($(strip $(GOPT_ENABLE_PROFESSOR2)),YES)
 	cd ${GENIE_REWEIGHT}/src && \
 	cd ProfSpline && make && cd .. && \
 	cd ${GENIE_REWEIGHT}
+else
+	@echo " "
+	@echo "** Professor2 was not enabled, Skipping ProfSpline"
+endif
 
 general-apps : reweight-framework reweight-io reweight-calculators prof-spline FORCE
 	@echo " "

--- a/src/Apps/Makefile
+++ b/src/Apps/Makefile
@@ -20,8 +20,11 @@ GENIE_REWEIGHT_LIBS  = $(shell $(GENIE_REWEIGHT)/src/scripts/setup/genie-reweigh
 LIBRARIES  := $(LIBRARIES) $(CERN_LIBRARIES) $(GENIE_LIBS) $(GENIE_REWEIGHT_LIBS)
 
 TGT_BASE =  grwght1p   \
-            grwghtnp   \
-						grwproftest
+            grwghtnp
+
+ifeq ($(strip $(GOPT_ENABLE_PROFESSOR2)),YES)
+TGT_BASE += grwproftest
+endif
 
 TGT = $(addprefix $(GENIE_REWEIGHT_BIN_PATH)/,$(TGT_BASE))
 

--- a/src/Apps/gRwProfTest.cxx
+++ b/src/Apps/gRwProfTest.cxx
@@ -30,12 +30,10 @@
 #include "RwCalculators/GReWeightXSecEmpiricalMEC.h"
 #include "RwCalculators/GReWeightXSecMEC.h"
 
-#ifdef __GENIE_PROFESSOR2_ENABLED__
 #include "RwCalculators/GReWeightProfessor.h"
 #include <ROOT/RDF/InterfaceUtils.hxx>
 #include <ROOT/RDF/RInterface.hxx>
 #include <ROOT/RDataFrame.hxx>
-#endif
 
 #include "TAttLine.h"
 #include "TF1.h"
@@ -95,7 +93,6 @@ std::pair<double, double> get_xsec(TH1 *h_rate, TGraph *spline) {
   return {event_rate, event_rate / fluxint};
 }
 
-#ifdef __GENIE_PROFESSOR2_ENABLED__
 ROOT::RDF::RResultPtr<TH1D> normalize_filter(ROOT::RDF::RNode df) {
   return df
       .Filter(
@@ -131,7 +128,6 @@ double get_genie_normalize(ROOT::RDF::RNode df, std::string filename, int Z) {
   xsec *= 1. / ((double)Z) * 1e-38;
   return xsec / tot;
 }
-#endif
 
 template <typename T> auto common_def(T &&df) {
   return df
@@ -237,7 +233,6 @@ int main(int argc, char **argv) {
   auto ipol_path = basedir + "ipol_test.dat";
   auto binningxml = basedir + "binning.xml";
 
-#ifdef __GENIE_PROFESSOR2_ENABLED__
   ROOT::RDataFrame input_from_tree(
       "gtree",
       input_from_file); // read the tree from the file
@@ -476,13 +471,6 @@ int main(int argc, char **argv) {
     do_plot(var, true, "1pi");
     do_plot(var, true, "Mpi");
   }
-
-#else
-  LOG("ReW", pFATAL)
-    << "Calling GReWeightProfessor without enabling Professor2";
-  gAbortingInErr = true;
-  std::exit(1);
-#endif
 
   return 0;
 }

--- a/src/Apps/gRwProfTest.cxx
+++ b/src/Apps/gRwProfTest.cxx
@@ -30,7 +30,13 @@
 #include "RwCalculators/GReWeightXSecEmpiricalMEC.h"
 #include "RwCalculators/GReWeightXSecMEC.h"
 
+#ifdef __GENIE_PROFESSOR2_ENABLED__
 #include "RwCalculators/GReWeightProfessor.h"
+#include <ROOT/RDF/InterfaceUtils.hxx>
+#include <ROOT/RDF/RInterface.hxx>
+#include <ROOT/RDataFrame.hxx>
+#endif
+
 #include "TAttLine.h"
 #include "TF1.h"
 #include "TLorentzVector.h"
@@ -38,9 +44,6 @@
 #include "TROOT.h"
 #include "TSpline.h"
 
-#include <ROOT/RDF/InterfaceUtils.hxx>
-#include <ROOT/RDF/RInterface.hxx>
-#include <ROOT/RDataFrame.hxx>
 #include <unordered_map>
 #include <vector>
 
@@ -92,6 +95,7 @@ std::pair<double, double> get_xsec(TH1 *h_rate, TGraph *spline) {
   return {event_rate, event_rate / fluxint};
 }
 
+#ifdef __GENIE_PROFESSOR2_ENABLED__
 ROOT::RDF::RResultPtr<TH1D> normalize_filter(ROOT::RDF::RNode df) {
   return df
       .Filter(
@@ -127,6 +131,7 @@ double get_genie_normalize(ROOT::RDF::RNode df, std::string filename, int Z) {
   xsec *= 1. / ((double)Z) * 1e-38;
   return xsec / tot;
 }
+#endif
 
 template <typename T> auto common_def(T &&df) {
   return df
@@ -232,6 +237,7 @@ int main(int argc, char **argv) {
   auto ipol_path = basedir + "ipol_test.dat";
   auto binningxml = basedir + "binning.xml";
 
+#ifdef __GENIE_PROFESSOR2_ENABLED__
   ROOT::RDataFrame input_from_tree(
       "gtree",
       input_from_file); // read the tree from the file
@@ -470,6 +476,13 @@ int main(int argc, char **argv) {
     do_plot(var, true, "1pi");
     do_plot(var, true, "Mpi");
   }
+
+#else
+  LOG("ReW", pFATAL)
+    << "Calling GReWeightProfessor without enabling Professor2";
+  gAbortingInErr = true;
+  std::exit(1);
+#endif
 
   return 0;
 }

--- a/src/RwCalculators/GReWeightProfessor.h
+++ b/src/RwCalculators/GReWeightProfessor.h
@@ -1,8 +1,11 @@
 #ifndef _G_REWEIGHT_PROFESSOR_
 #define _G_REWEIGHT_PROFESSOR_
 
+#include "Framework/Conventions/GBuild.h"
+#ifdef __GENIE_PROFESSOR2_ENABLED__
 #include "ProfSpline/KinematicVariables.h"
 #include "ProfSpline/ObservableSplines.h"
+#endif
 #include "RwCalculators/GReWeightModel.h"
 #include <string>
 
@@ -21,10 +24,13 @@ public:
   virtual void Reconfigure(void) override;
   virtual double CalcWeight(const genie::EventRecord &event) override;
 
+
+#ifdef __GENIE_PROFESSOR2_ENABLED__
   std::map<std::tuple<std::string /*configuration full id*/,
                       ChannelIDs /*Channel selection ID*/>,
            std::vector<std::string> /*the vars lines from prof2*/>
   ReadProf2Spline(std::string filepath);
+#endif
 
   void SetSystematic(const std::vector<double> &m_systematics_values,
                      const std::vector<double> &m_orig_value) {
@@ -34,8 +40,10 @@ public:
 
   void ReadComparisonXML(std::string filepath, std::string spline_path);
 
-private:
+ private:
+#ifdef __GENIE_PROFESSOR2_ENABLED__
   std::vector<ObservableSplines> observables{};
+#endif
   std::vector<double> systematics_values, orig_value;
   std::vector<std::string> spline_vars;
   std::vector<double> var_min, var_max;

--- a/src/RwCalculators/GReWeightProfessor.h
+++ b/src/RwCalculators/GReWeightProfessor.h
@@ -40,7 +40,7 @@ public:
 
   void ReadComparisonXML(std::string filepath, std::string spline_path);
 
- private:
+private:
 #ifdef __GENIE_PROFESSOR2_ENABLED__
   std::vector<ObservableSplines> observables{};
 #endif

--- a/src/scripts/setup/genie-reweight-config
+++ b/src/scripts/setup/genie-reweight-config
@@ -4,6 +4,9 @@
 # genie-reweight-config a la ROOT's root-config
 #
 
+### GENIE config options:
+. $GENIE/src/make/Make.config_no_paths
+
 ### GENIE/Reweight libraries path:
 libdir=$GENIE_REWEIGHT/lib
 
@@ -22,11 +25,16 @@ fi
 srcdir=$GENIE_REWEIGHT/src
 
 ### GENIE/Reweight libraries:
-libs="-L$libdir -lGRwFwk -lGRwIO -lGRwClc -lGPrSp"
+libs="-L$libdir -lGRwFwk -lGRwIO -lGRwClc"
+
+# (optional)
+if test "$GOPT_ENABLE_PROFESSOR2" == "YES"; then
+ libs="$libs -lGPrSp"
+fi
 
 ### Usage
 usage="\
-Usage: genie-reweight-config [--libs] [--libdir] [--topsrcdir]" 
+Usage: genie-reweight-config [--libs] [--libdir] [--topsrcdir]"
 
 if test $# -eq 0; then
    echo "${usage}" 1>&2


### PR DESCRIPTION
Use changes in Generator's Make.config_no_paths and GBuild.h to ignore the ProfSpline subdirectory as appropriate and to conditionally compile parts of GReWeightProfessor and gRwProfTest code.   Only link in ProfSpline (-lGPrSp) library if it's built.

One semi-unrelated issue is with gRwProfTest's use for RDFrame (and friend) which tries to include a nlohmann/json.hpp header with doesn't seem to be always available.   Since it's only used for gRwProfTest made that also conditional on Professor2 being enabled (even though those are strictly coupled).