### PR TITLE
Use phase space stored in event instead of hard-coding

### DIFF
--- a/src/RwCalculators/GReWeightNuXSecCCRES.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCCRES.cxx
@@ -276,7 +276,7 @@ double GReWeightNuXSecCCRES::CalcWeightMaMv(const genie::EventRecord & event)
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSWQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
@@ -312,7 +312,7 @@ double GReWeightNuXSecCCRES::CalcWeightMaMvShape(const genie::EventRecord & even
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSWQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {

--- a/src/RwCalculators/GReWeightNuXSecCOH.cxx
+++ b/src/RwCalculators/GReWeightNuXSecCOH.cxx
@@ -191,7 +191,7 @@ double GReWeightNuXSecCOH::CalcWeight(const genie::EventRecord & event)
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSxyfE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {

--- a/src/RwCalculators/GReWeightNuXSecDIS.cxx
+++ b/src/RwCalculators/GReWeightNuXSecDIS.cxx
@@ -269,7 +269,7 @@ double GReWeightNuXSecDIS::CalcWeightABCV12uShape(const genie::EventRecord & eve
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSxyfE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {

--- a/src/RwCalculators/GReWeightNuXSecNCRES.cxx
+++ b/src/RwCalculators/GReWeightNuXSecNCRES.cxx
@@ -264,7 +264,7 @@ double GReWeightNuXSecNCRES::CalcWeightMaMv(const genie::EventRecord & event)
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSWQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {
@@ -300,7 +300,7 @@ double GReWeightNuXSecNCRES::CalcWeightMaMvShape(const genie::EventRecord & even
 
   interaction->KinePtr()->UseSelectedKinematics();
 
-  const KinePhaseSpace_t phase_space = kPSWQ2fE;
+  const KinePhaseSpace_t phase_space = event.DiffXSecVars();
 
   double old_xsec   = event.DiffXSec();
   if (!fUseOldWeightFromFile || fNWeightChecksDone < fNWeightChecksToDo) {


### PR DESCRIPTION
There were a handful of reweight calculators that were hard-coding the phase space variables the cross section is to be calculated in.  However, that falls down if the phase space for the diff xsec stored in the event, which is the default denominator for the reweight ratio, is different from the hard-coded phase space.

Some instances of this were corrected some number of years ago (e.g., in the CCQE calculator).  This PR fixes the remaining instances that I found.