### PR TITLE
fix `GSystSet` copy constructor that didn't copy (!)

### DIFF
--- a/src/RwFramework/GSystSet.cxx
+++ b/src/RwFramework/GSystSet.cxx
@@ -108,7 +108,7 @@ void GSystSet::Print(void)
 //_______________________________________________________________________________________
 void GSystSet::Copy(const GSystSet & syst_set)
 {
-  return fSystematics.clear();
+  fSystematics.clear();
 
   map<GSyst_t, GSystInfo*>::const_iterator it = syst_set.fSystematics.begin();
   for( ; it != syst_set.fSystematics.end(); ++it) {


### PR DESCRIPTION
I'm not sure how this hasn't been discovered before, but the `GSystSet::Copy()` method didn't actually copy anything (instead returning immediately), which meant the `GSystSet` copy constructor (which internally forwards to `Copy()`) wasn't copying either, instead behaving like a default constructor (!).  It looks like it must have been a typo (`return <return value of a function that returns void>` is a rather unexpected construction...).

Fix it so that it at least does what it says on the tin...