### PR TITLE
don't allow copying of `GReWeight`

### DIFF
--- a/src/RwFramework/GReWeight.h
+++ b/src/RwFramework/GReWeight.h
@@ -39,6 +39,10 @@ namespace rew   {
  {
  public:
    GReWeight();
+   GReWeight(const GReWeight& other) = delete;             // since we OWN pointers, we can't be copied
+   GReWeight& operator= (const GReWeight& other) = delete; // ... or assigned
+   GReWeight(GReWeight&& other) = default;                 // but if the other object is MOVED, that's ok, since only one instance owns the memroy
+   GReWeight& operator= (GReWeight&& other) = default;     // etc.
   ~GReWeight();
 
    void        AdoptWghtCalc (string name, GReWeightI* wcalc);   ///< add concrete weight calculator, transfers ownership


### PR DESCRIPTION
`GReWeight` contains raw pointers, which means that if it's copied by a default constructor, the pointers will be copied.  However, `GReWeight` is intended to be the class that manages this memory, and so it `delete`s the pointers when its destructor is called.  In the case of a copy, this leads to double `delete`s when both old and new instances eventually try to clear up the same memory in `CleanUp()`. So, here we explicitly disable the copy constructor and assignment operators.

However, it's perfectly fine to *move* another instance into this one, because there's only ever one owner of the memory in that case, so move constructor & move assign are enabled.

(A better solution would be to switch to `unique_ptr`s, which can't be copied at all, but I didn't have the time to actually go through and adjust all the usages to suit that.  And anyway that would require a breaking API change for `AdoptWghtCalc`, which would require some discussion.  So I didn't go that route, at least for now.)